### PR TITLE
chore: update @dylibso/mcpx to the latest version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2025 Dylibso, Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@dylibso/mcpx-anthropic",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dylibso/mcpx-anthropic",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.35.0",
-        "@dylibso/mcpx": "^0.21.0",
+        "@anthropic-ai/sdk": "^0.36.0",
+        "@dylibso/mcpx": "^0.23.0",
         "pino": "^9.6.0"
       },
       "devDependencies": {
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.35.0.tgz",
-      "integrity": "sha512-JxVuNIRLjcXZbDW/rJa3vSIoYB5c0wgIQUPsjueeqli9OJyCJpInj0UlvKSSk6R2oCYyg0y2M0H8n8Wyt0l1IA==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.36.3.tgz",
+      "integrity": "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -34,10 +34,10 @@
       }
     },
     "node_modules/@dylibso/mcpx": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@dylibso/mcpx/-/mcpx-0.21.0.tgz",
-      "integrity": "sha512-hcuzqVXygjxTdlun6Z0PPNx1Onwh5oBIsNI3fqZe4nW80tj4hqodyKUcHY/ebIugKwk9bIX5reTnJc+wKipKdA==",
-      "license": "UNLICENSED",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@dylibso/mcpx/-/mcpx-0.23.0.tgz",
+      "integrity": "sha512-8xpgZqY6a8djj0lf0jqf3D0wWsO4Db9FxBwpt0Sak/pB5aVqJ1aLNJ8haY+osnYgz2W0zQDg3bSTDhUtyWCRVA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@dylibso/xtp": "^0.0.0-rc13",
         "@extism/extism": "=2.0.0-rc10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "BSD-3-Clause",
   "description": "",
   "devDependencies": {
     "esbuild": "^0.24.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dylibso/mcpx-anthropic",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "scripts": {
     "prepare": "npm run build",
@@ -23,8 +23,8 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.35.0",
-    "@dylibso/mcpx": "^0.21.0",
+    "@anthropic-ai/sdk": "^0.36.0",
+    "@dylibso/mcpx": "^0.23.0",
     "pino": "^9.6.0"
   }
 }


### PR DESCRIPTION
Related to https://github.com/dylibso/mcp.run/issues/281

Also updates the package license to match https://github.com/dylibso/mcpx-openai-node