### PR TITLE
fix: move the bailout check after the last tool calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,10 +53,6 @@ export class Driver {
         content: response.content,
       })
 
-      if (response.stop_reason !== 'tool_use') {
-        break
-      }
-
       for (; messageIdx < messages.length; ++messageIdx) {
         this.#logger.info({ exchange: messages[messageIdx] }, 'message')
       }
@@ -99,6 +95,10 @@ export class Driver {
             is_error: true
           })
         }
+      }
+
+      if (response.stop_reason !== 'tool_use') {
+        break
       }
     } while (1)
     for (; messageIdx < messages.length - 1; ++messageIdx) {


### PR DESCRIPTION
Just in case there are tool calls left to execute. This addresses @nilslice's issues from the team meeting today, where the task exits with a tool call before invoking the tool.