### PR TITLE
fix: always emit last message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,10 +102,7 @@ export class Driver {
         break
       }
     } while (1)
-    for (; messageIdx < messages.length - 1; ++messageIdx) {
-      this.#logger.info({ exchange: messages[messageIdx] }, 'message')
-    }
-    this.#logger.info({ lastMessage: messages[messageIdx] }, 'final message')
+    this.#logger.info({ lastMessage: messages[messages.length - 1] }, 'final message')
     return response
   }
 }


### PR DESCRIPTION
D'oh. We no longer need to "catch up" to the last message emitted because the exit point of the loop moved. Instead, always emit the last message in the list as `lastMessage`. 