### PR TITLE
feat: support single-step advancement

### DIFF
--- a/examples/chat/package-lock.json
+++ b/examples/chat/package-lock.json
@@ -18,11 +18,11 @@
     },
     "../..": {
       "name": "@dylibso/mcpx-anthropic",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "1.0.8",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.35.0",
-        "@dylibso/mcpx": "^0.21.0",
+        "@anthropic-ai/sdk": "^0.36.0",
+        "@dylibso/mcpx": "^0.27.0",
         "pino": "^9.6.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dylibso/mcpx-anthropic",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dylibso/mcpx-anthropic",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node esbuild.js",
     "postbuild": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --project ./tsconfig.json --declaration --outDir dist",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export class Driver {
     let response: Anthropic.Messages.Message
     let { messages, ...rest } = body
     let messageIdx = 1
-    let stopReason = null
     do {
       const result =
         await this.messageStep({
@@ -60,12 +59,10 @@ export class Driver {
       response = result.response
       messages = result.messages
       messageIdx = result.index
-      stopReason = result.stopReason
       if (result.done) {
         break
       }
     } while (1)
-    this.#logger.info({ lastMessage: messages[messages.length - 1], stopReason }, 'final message')
     return response
   }
 
@@ -146,6 +143,7 @@ export class Driver {
     }
 
     messages.pop()
+    this.#logger.info({ lastMessage: messages[messages.length - 1], stopReason: response.stop_reason }, 'final message')
     return { response,  messages, index: messageIdx, stopReason: response.stop_reason, done: true }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export class Driver {
     let messageIdx = 1
     do {
       const result =
-        await this.messageStep({
+        await this.nextTurn({
           ...rest,
           ...(this.#tools.length ? { tools: this.#tools } : {}),
           messages,
@@ -65,7 +65,7 @@ export class Driver {
     return response
   }
 
-  async messageStep(body: MessageCreateParamsNonStreaming, messageIdx: number, options: RequestOptions): Promise<McpxAnthropicStage> {
+  async nextTurn(body: MessageCreateParamsNonStreaming, messageIdx: number, options: RequestOptions): Promise<McpxAnthropicStage> {
     let { messages, ...rest } = body
     let response: Anthropic.Messages.Message = await this.#anthropic.messages.create({
       ...rest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,9 +204,6 @@ export class ToolSchemaError extends Error {
   constructor(error: any, toolIndex: number) {
     super(error.message)
 
-    // Required for instanceof https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    Object.setPrototypeOf(this, ToolSchemaError.prototype);
-
     this.originalError = error;
     this.toolIndex = toolIndex
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ export interface McpxAnthropicStage {
   response: Anthropic.Messages.Message
   messages: Anthropic.Messages.MessageParam[]
   index: number
-  stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | null,
   done: boolean
 }
 
@@ -135,16 +134,16 @@ export class Driver {
     }
 
     if (response.stop_reason === 'tool_use') {
-      return { response,  messages, index: messageIdx, stopReason: response.stop_reason, done: false }
+      return { response,  messages, index: messageIdx, done: false }
     }
 
     if (response.stop_reason === 'end_turn' && toolUseCount > 0) {
-      return { response,  messages, index: messageIdx, stopReason: response.stop_reason, done: false }
+      return { response,  messages, index: messageIdx, done: false }
     }
 
     messages.pop()
     this.#logger.info({ lastMessage: messages[messages.length - 1], stopReason: response.stop_reason }, 'final message')
-    return { response,  messages, index: messageIdx, stopReason: response.stop_reason, done: true }
+    return { response,  messages, index: messageIdx, done: true }
   }
 }
 

--- a/test/toolSchemaError.test.ts
+++ b/test/toolSchemaError.test.ts
@@ -1,0 +1,97 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { ToolSchemaError } from '../src/index.ts';
+
+describe('ToolSchemaError', () => {
+  describe('parse', () => {
+    test('should return original error if not a tool schema error', () => {
+      const originalError = new Error('Not a schema error');
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return original error if error type is not invalid_request_error', () => {
+      const originalError = { 
+        error: { 
+          error: { 
+            type: 'other_error', 
+            message: 'tools.0.input_schema has an error' 
+          } 
+        } 
+      };
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return original error if message does not include input_schema', () => {
+      const originalError = { 
+        error: { 
+          error: { 
+            type: 'invalid_request_error', 
+            message: 'some other error message' 
+          } 
+        } 
+      };
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return original error if message does not start with tools.', () => {
+      const originalError = { 
+        error: { 
+          error: { 
+            type: 'invalid_request_error', 
+            message: 'input_schema has an error but not in the expected format' 
+          } 
+        } 
+      };
+      assert.strictEqual(ToolSchemaError.parse(originalError), originalError);
+    });
+
+    test('should return a ToolSchemaError when conditions are met', () => {
+      const originalError = { 
+        error: { 
+          error: { 
+            type: 'invalid_request_error', 
+            message: 'tools.2.input_schema has invalid properties' 
+          } 
+        },
+        message: 'Original error message'
+      };
+      
+      const result = ToolSchemaError.parse(originalError);
+      
+      assert.ok(result instanceof ToolSchemaError);
+      assert.strictEqual(result.originalError, originalError);
+      assert.strictEqual(result.toolIndex, 2);
+    });
+  });
+
+  describe('constructor', () => {
+    test('should set originalError and toolIndex properties', () => {
+      const originalError = new Error('Test error');
+      const toolIndex = 3;
+      
+      const error = new ToolSchemaError(originalError, toolIndex);
+      
+      assert.strictEqual(error.originalError, originalError);
+      assert.strictEqual(error.toolIndex, toolIndex);
+    });
+
+    test('should use the error message from the original error', () => {
+      const originalError = new Error('Test error message');
+      const toolIndex = 1;
+      
+      const error = new ToolSchemaError(originalError, toolIndex);
+      
+      assert.strictEqual(error.message, originalError.message);
+    });
+
+    test('should properly maintain instanceof checks', () => {
+      const originalError = new Error('Test error');
+      const toolIndex = 0;
+      
+      const error = new ToolSchemaError(originalError, toolIndex);
+      
+      assert.ok(error instanceof ToolSchemaError);
+      assert.ok(error instanceof Error);
+    });
+  });
+});

--- a/test/toolschema.test.js
+++ b/test/toolschema.test.js
@@ -1,0 +1,10 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { ToolSchemaError } from '../dist/index.js';
+
+describe('ToolSchemaError JS compatibility', () => {
+  test('should be instanceof ToolSchemaError', () => {
+    // Verify we don't need to explicitly Object.setPrototypeOf(this, ToolSchemaError.prototype);
+    assert.ok(new ToolSchemaError(new Error(), 0) instanceof ToolSchemaError)
+  })
+})


### PR DESCRIPTION
introduce `messageStep()`, this allows to evaluate a single response, perform tool invocations and return the current cursor index.
