### PR TITLE
feat: support mid-turn advancement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ export class Driver {
             messages,
           }, requestOptions)
         } catch (err: any) {
-          throw ToolSchemaError.parse(err)
+          throw ToolSchemaError.parse(err, this.#tools)
         }
 
         messages.push({
@@ -276,14 +276,14 @@ export default async function createDriver(opts: DriverOptions) {
 }
 
 export class ToolSchemaError extends Error {
-  static parse(err: any): any {
+  static parse(err: any, tools: Tool[]): any {
     const error = err?.error?.error
     const message = error?.message
     if (error?.type === 'invalid_request_error' && message?.includes('input_schema')) {
       if (message.startsWith("tools.")) {
         const parts: string[] = message.split('.')
         const index = parseInt(parts[1])
-        return new ToolSchemaError(err, index)
+        return new ToolSchemaError(err, index, tools[index].name)
       }
     }
     return err
@@ -291,11 +291,13 @@ export class ToolSchemaError extends Error {
 
   public readonly originalError: any
   public readonly toolIndex: number
-  constructor(error: any, toolIndex: number) {
+  public readonly toolName: string
+  constructor(error: any, toolIndex: number, toolName: string) {
     super(error.message)
 
     this.originalError = error;
     this.toolIndex = toolIndex
+    this.toolName = toolName
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,8 +293,7 @@ export class ToolSchemaError extends Error {
   public readonly toolIndex: number
   public readonly toolName: string
   constructor(error: any, toolIndex: number, toolName: string) {
-    super(error.message)
-
+    super(`Invalid schema for tool #${toolIndex}: '${toolName}'\nCaused by: ${error.message}`)
     this.originalError = error;
     this.toolIndex = toolIndex
     this.toolName = toolName

--- a/test/toolSchemaError.test.ts
+++ b/test/toolSchemaError.test.ts
@@ -67,6 +67,7 @@ describe('ToolSchemaError', () => {
       assert.strictEqual(result.originalError, originalError);
       assert.strictEqual(result.toolIndex, 2);
       assert.strictEqual(result.toolName, 'tool3');
+      assert.strictEqual(result.message, "Invalid schema for tool #2: 'tool3'\nCaused by: Original error message");
     });
   });
 
@@ -82,13 +83,13 @@ describe('ToolSchemaError', () => {
       assert.strictEqual(error.toolName, 'tool4');
     });
 
-    test('should use the error message from the original error', () => {
+    test('should include the error message from the original error', () => {
       const originalError = new Error('Test error message');
       const toolIndex = 1;
       
       const error = new ToolSchemaError(originalError, toolIndex, 'MyTool');
       
-      assert.strictEqual(error.message, originalError.message);
+      assert.ok(error.message.includes(originalError.message));
     });
 
     test('should properly maintain instanceof checks', () => {

--- a/test/toolschema.test.js
+++ b/test/toolschema.test.js
@@ -5,6 +5,6 @@ import { ToolSchemaError } from '../dist/index.js';
 describe('ToolSchemaError JS compatibility', () => {
   test('should be instanceof ToolSchemaError', () => {
     // Verify we don't need to explicitly Object.setPrototypeOf(this, ToolSchemaError.prototype);
-    assert.ok(new ToolSchemaError(new Error(), 0) instanceof ToolSchemaError)
+    assert.ok(new ToolSchemaError(new Error(), 0, 'blah') instanceof ToolSchemaError)
   })
 })


### PR DESCRIPTION
follow up to #5 

introduce:

- McpxAnthropicTurn
- repurpose McpxAnthropicStage to mean "mid-turn"
- introduce next(), which might interrupt mid-turn with a function call
- rewrite nextTurn() in terms of next()

additionally, we ensure we actually use the tool name when we throw an error (I did not realize in #5 we have the tool names available here).