### PR TITLE
feat: forced result tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,8 @@ export class Driver {
         const nextTool = toolUseCount + 1
         const nextSubmessage = submessageIdx + 1
         if (nextSubmessage >= inputMessage.content.length) {
-          return { response, messages, index, status: 'pending', resultStatus }
+          const resultStatus_ = resultStatus === 'pending'? 'ready': resultStatus
+          return { response, messages, index, status: 'pending', resultStatus: resultStatus_ }
         } else {
           return { response, messages, index, status: 'input_wait', toolCallIndex: nextTool, submessageIdx: nextSubmessage, resultStatus }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { pino } from 'pino'
 export interface BaseDriverOptions {
   anthropic: Anthropic,
   logger?: Logger,
+  forceTool?: string;
+  tools?: { name: string, description?: string, inputSchema: any }[]
 }
 
 export type DriverOptions = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,6 @@ import { pino } from 'pino'
 export interface BaseDriverOptions {
   anthropic: Anthropic,
   logger?: Logger,
-  forceTool?: string;
-  tools?: { name: string, description?: string, inputSchema: any }[]
 }
 
 export type DriverOptions = (
@@ -40,6 +38,16 @@ export interface McpxAnthropicStage {
 }
 
 
+function anthropicToolCallToMcpxToolCall(submessage: any): any {
+  return {
+    method: 'tools/call',
+    params: {
+      name: submessage.name,
+      arguments: submessage.input,
+    },
+  }
+}
+
 /**
  * A Driver wrapping an Anthropic client and MCPX session.
  *
@@ -55,8 +63,7 @@ export class Driver {
     anthropic: Anthropic,
     logger: Logger,
     session: Session,
-    tools: Tool[],
-    forceTool?: string
+    tools: Tool[]
   }) {
     this.#anthropic = opts.anthropic
     this.#logger = opts.logger
@@ -125,23 +132,16 @@ export class Driver {
   }
 
 
-  private async call(submessage: ToolUseBlock): Promise<ContentBlockParam> {
-    const { id, input, name } = submessage
+  private async call(convertedToolCall: any, toolCallId: string): Promise<ContentBlockParam> {
     try {
       const abortcontroller = new AbortController()
       const result = await this.#session.handleCallTool(
-        {
-          method: 'tools/call',
-          params: {
-            name,
-            arguments: input as any,
-          },
-        },
+        convertedToolCall,
         { signal: abortcontroller.signal },
       )
 
       return {
-        tool_use_id: id,
+        tool_use_id: toolCallId,
         type: 'tool_result',
         content: Array.isArray(result.content)
           ? result.content.map(xs => {
@@ -152,7 +152,7 @@ export class Driver {
     } catch (err: any) {
       this.#logger.error(
         {
-          tool_use_id: id,
+          tool_use_id: toolCallId,
           name,
           error: err.message,
           stack: err.stack,
@@ -160,7 +160,7 @@ export class Driver {
         'tool use failed',
       )
       return {
-        tool_use_id: id,
+        tool_use_id: toolCallId,
         type: 'tool_result',
         content: err.toString(),
         is_error: true,
@@ -221,33 +221,48 @@ export class Driver {
         return { response,  messages, index: messageIdx, status: 'ready' }
       }
       case 'input_wait': {
-        const toolUseCount = stage.toolCallIndex!
-        const submessageIdx = stage.submessageIdx!
-        const inputMessage = messages[index-1]
         const newMessage = messages[index]
-
-        this.#logger.info({ m:"message index", index, len: messages.length })
-
-        // when status == 'input_wait' it is always a tool call,
-        // newMessage.content is always a ContentBlockParam[]
-        const submessage = inputMessage.content[submessageIdx] as ToolUseBlock
         const content = newMessage.content as ContentBlockParam[]
-        content.push(await this.call(submessage))
+        const { tool, submessageIdx, toolCallIndex, toolCallLength, toolCallId } =
+          this.parseNextToolCall(stage)
 
-        const nextTool = toolUseCount + 1
-        const nextSubmessage = submessageIdx + 1
-        if (nextSubmessage >= inputMessage.content.length) {
+        content.push(await this.call(tool, toolCallId!))
+
+        if (submessageIdx >= toolCallLength) {
           return { response, messages, index, status: 'pending' }
         } else {
-          return { response, messages, index, status: 'input_wait', toolCallIndex: nextTool, submessageIdx: nextSubmessage }
+          return { response, messages, index, status: 'input_wait', toolCallIndex, submessageIdx }
         }
-
       }
       default:
         throw new Error("Illegal status: " + status)
     }
   }
 
+  parseNextToolCall(stage: McpxAnthropicStage) {
+    const { status, messages, index } = stage
+    if (status !== 'input_wait') {
+      throw new Error("Cannot parse next tool call: invalid status " + status)
+    }
+    const toolUseCount = stage.toolCallIndex!
+    const submessageIdx = stage.submessageIdx!
+    const inputMessage = messages[index-1]
+
+    // when status == 'input_wait' it is always a tool call,
+    // newMessage.content is always a ContentBlockParam[]
+    const submessage = inputMessage.content[submessageIdx] as ToolUseBlock
+
+    const nextTool = toolUseCount + 1
+    const nextSubmessage = submessageIdx + 1
+
+    return {
+      tool: anthropicToolCallToMcpxToolCall(submessage),
+      toolCallIndex: nextTool,
+      toolCallLength: inputMessage.content.length,
+      submessageIdx: nextSubmessage,
+      toolCallId: submessage.id
+    }
+  }
 
 }
 
@@ -281,8 +296,7 @@ export default async function createDriver(opts: DriverOptions) {
     anthropic,
     logger: logger || (session.logger as any) || pino({ level: 'silent' }),
     session,
-    tools: mcpTools.map(mcpxToolToAnthropic),
-    forceTool: opts.forceTool,
+    tools: mcpTools.map(mcpxToolToAnthropic)
   })
 }
 


### PR DESCRIPTION
allow passing an optional `config` to `next()`. The allowed keys are the anthropic config keys, plus:

- `tools: Tool[]` (an MCP tool def)
- `tool_choice?: string`, if present, the name of exactly one tool in the tool list (either the one provided, or the one returned by the session)

